### PR TITLE
Fix react-loading-skeleton conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^3.10.0",
-    "react-loading-skeleton": "^2.1.1",
+    "react-loading-skeleton": "^3.3.1",
     "react-lottie": "^1.2.3",
     "next": "13.4.19",
     "react-spring": "^8.0.27",


### PR DESCRIPTION
## Summary
- update `react-loading-skeleton` to a version compatible with React 18

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68843221dc04832db643071280bee535