### PR TITLE
Fix react-switch peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-lottie": "^1.2.3",
     "next": "13.4.19",
     "react-spring": "^8.0.27",
-    "react-switch": "^5.0.1",
+    "react-switch": "^7.0.0",
     "react-transition-group": "^4.4.1",
     "styled-components": "^5.3.0",
     "typescript": "^5.4.2",


### PR DESCRIPTION
## Summary
- update `react-switch` to a version compatible with React 18

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688432ebcd8c832dbc6a90e5006ca3b9