### PR TITLE
Fix eslint deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.3.1",
@@ -13,7 +13,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@unform/core": "^2.1.3",
@@ -56,8 +56,8 @@
     "@types/react-lottie": "^1.2.5",
     "@types/react-transition-group": "^4.4.1",
     "@types/styled-components": "^5.1.1",
-    "@typescript-eslint/eslint-plugin": "^2.30.0",
-    "@typescript-eslint/parser": "^2.30.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
## Summary
- bump Node.js engine to 22.x
- upgrade @typescript-eslint packages
- bump `@types/node`

## Testing
- `npm test` *(fails: No tests specified)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884337312e8832d83bd216e4bbdb61b