### PR TITLE
Fix eslint dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.57.0",
-    "eslint-config-airbnb": "^18.1.0",
+    "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-import": "^2.20.1",


### PR DESCRIPTION
## Summary
- update eslint-config-airbnb to a version compatible with eslint 8

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68843443105c832d9c43f5036c958c19