### PR TITLE
Fix ESLint peer dependency mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
-    "eslint-plugin-react-hooks": "^2.5.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- resolve eslint-plugin-react-hooks peer dependency

## Testing
- `npm install` *(fails: 403 Forbidden for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688435ab5868832d852d41f6252b23a4