### PR TITLE
Fix repository route

### DIFF
--- a/src/pages/repository/[...repository].tsx
+++ b/src/pages/repository/[...repository].tsx
@@ -24,7 +24,9 @@ const Repository = ({ toggleTheme }: ToggleTheme) => {
   const [hasMoreIssues, setHasMoreIssues] = useState(true);
 
   const router = useRouter();
-  const { repository: repoParam } = router.query as Partial<RepositoryParamsProps>;
+  const { repository: repoParam } =
+    router.query as Partial<RepositoryParamsProps>;
+  const repoPath = Array.isArray(repoParam) ? repoParam.join('/') : repoParam;
 
   const [allIssues, setAllIssues] = useState<IssueProps[]>([]);
 
@@ -32,8 +34,8 @@ const Repository = ({ toggleTheme }: ToggleTheme) => {
   useEffect(() => {
     const fetchRepositoryData = async () => {
       try {
-        if (!repoParam) return;
-        const repositoryResponse = await api.get(`repos/${repoParam}`);
+        if (!repoPath) return;
+        const repositoryResponse = await api.get(`repos/${repoPath}`);
         setRepositories(repositoryResponse.data);
       } catch (error) {
         console.error('Erro ao buscar dados do repositório:', error);
@@ -43,11 +45,11 @@ const Repository = ({ toggleTheme }: ToggleTheme) => {
     const fetchIssuesData = async () => {
       try {
         const issuesResponse = await api.get(
-          `repos/${repoParam}/issues`,
+          `repos/${repoPath}/issues`,
           {
             params: {
               page,
-              per_page: 10, 
+              per_page: 10,
             },
           },
         );
@@ -63,7 +65,7 @@ const Repository = ({ toggleTheme }: ToggleTheme) => {
 
     fetchRepositoryData();
     fetchIssuesData();
-  }, [repoParam, page]);
+  }, [repoPath, page]);
 
   const handleSearch = (val: string) => {
     if (null !== inputRef.current) {

--- a/src/utils/repositoryInterfaces.ts
+++ b/src/utils/repositoryInterfaces.ts
@@ -28,5 +28,5 @@ export interface IssueProps {
 }
 
 export interface RepositoryParamsProps {
-  repository: string;
+  repository: string | string[];
 }


### PR DESCRIPTION
## Summary
- support `owner/repo` path by turning repository route into a catch-all
- update route param handling to accept arrays

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68843c167a98832da9af6a5a8b95eb81