### PR TITLE
Fix missing return in Logo component

### DIFF
--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -5,7 +5,7 @@ type PropsLogo = {
 };
 
 function Logo({ isDark }: PropsLogo) {
-  isDark === false ? (
+  return isDark === false ? (
     <svg
       height="60"
       viewBox="0 0 512.002 512.002"


### PR DESCRIPTION
## Summary
- add missing return statement in Logo component

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6886487b8500832d9e1db05c62c64785