### PR TITLE
Fix Logo import in Header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,7 +5,7 @@ import { shade } from 'polished';
 
 import { ThemeContext } from 'styled-components';
 import * as S from './styles';
-import { Logo } from '../Logo';
+import Logo from '../Logo';
 
 interface HeaderProps {
   isLink?: string;


### PR DESCRIPTION
## Summary
- fix incorrect named import of `Logo` component in Header

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68864a8485c0832db242941ce957c367