### PR TITLE
Fix Lottie types

### DIFF
--- a/src/components/Animation/index.tsx
+++ b/src/components/Animation/index.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
-import Lottie from 'react-lottie';
+import LottieLib from 'react-lottie';
+import type { LottieProps } from 'react-lottie';
 import { Container } from './styles';
+
+const Lottie = LottieLib as unknown as React.ComponentType<LottieProps>;
 
 import animationData from '../../assets/25920-questions.json';
 


### PR DESCRIPTION
## Summary
- fix Animation component type error by casting the Lottie import

## Testing
- `yarn install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68866424dae8832d9bccdb439918f012