### PR TITLE
Fix use of ThemeContext in Header component

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,9 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import Switch from 'react-switch';
 import Link from 'next/link';
 import { shade } from 'polished';
-
-import { ThemeContext } from 'styled-components';
+import { useTheme } from 'styled-components';
 import * as S from './styles';
 import Logo from '../Logo';
 
@@ -17,7 +16,7 @@ const handleBack = () => {
 };
 
 const Header: React.FC<HeaderProps> = ({ isLink, toggleTheme }) => {
-  const { colors, title } = useContext(ThemeContext);
+  const { colors, title } = useTheme();
 
   return (
     <S.Container>


### PR DESCRIPTION
## Summary
- remove unused React `useContext` usage and import
- utilize `useTheme` hook from styled-components to access the current theme

## Testing
- `npx tsc -p . --noEmit` *(fails: Cannot find module '@types/*' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68866c90d35c832da2ed2a89b4f8bc1f