### PR TITLE
Fix ThemeProvider typing error

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
 import type { AppProps } from 'next/app';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components';
 import type { DefaultTheme } from 'styled-components';
 import GlobalStyle from '../styles/global';
 import light from '../styles/themes/light';
 import dark from '../styles/themes/dark';
+
+const ThemeProvider: React.FC<{ theme: DefaultTheme }> = ({ theme, children }) => (
+  <StyledComponentsThemeProvider theme={theme}>{children}</StyledComponentsThemeProvider>
+);
 
 const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
   const [theme, setTheme] = useState<DefaultTheme>(light);


### PR DESCRIPTION
## Summary
- wrap styled-components ThemeProvider in a React FC to satisfy JSX requirements

## Testing
- `yarn test` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_e_68869bc7cd78832db5f0acde3792d0e1